### PR TITLE
Add wmlscope check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,14 @@ jobs:
       with:
         wesnoth-version: ${{ env.WESNOTH_VERSION }}
         spellcheck: false
+    - name: Verify resources scope
+      uses: czyzby/wesnoth-wml-scope@v1
+      if: always()
+      with:
+        wesnoth-version: ${{ env.WESNOTH_VERSION }}
     - name: Verify images
       uses: czyzby/wesnoth-png-optimizer@v1
+      if: always()
       with:
         wesnoth-version: ${{ env.WESNOTH_VERSION }}
         threshold: 5


### PR DESCRIPTION
Adds `wmlscope` check to the GitHub Actions pipeline. Ensures that PNG optimization and `wmlscope` are ran even if the linter step has failed.

If you don't want to include `wmlscope` checks in your project, feel free to close the PR, but consider adding `if: always()` to PNG optimizer so that it's not skipped.