### PR TITLE
Mechanizing Virus

### DIFF
--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -353,3 +353,165 @@ Enemy units cannot see this unit while it is in a swamp hex, except if they have
         [/filter_self]
     [/hides]
 #enddef
+
+#define ABILITY_MECHANIZING_VIRUS
+	[dummy]
+		id=mechanizing_virus
+		name= _ "mechanizing virus"
+		description= _ "Each time this unit hits with a melee weapon, it has a 5% chance to transmit the mechanizing virus, turning the enemy into a member of the Steelhive."
+	[/dummy]
+#enddef
+
+#define ABILITY_STEELHIVE_EVENTS
+	[event]
+		name=attacker hits
+		first_time_only=no
+		[filter]
+			ability=mechanizing_virus
+		[/filter]
+		[filter_second]
+			[not]
+				race=steelhive
+			[/not]
+			[not]
+				canrecruit=yes
+			[/not]
+			formula="hitpoints>0"
+		[/filter_second]
+		[filter_attack]
+			range=melee
+		[/filter_attack]
+		{VARIABLE_OP infection rand (1..100)}
+		[if]
+			[variable]
+				name=infection
+				less_than_equal_to=5
+			[/variable]
+			[then]
+				[transform_unit]
+					id=$second_unit.id
+					[filter_wml]
+						usage=scout
+					[/filter_wml]
+					transform_to=Steel Wyrm
+				[/transform_unit]
+				[transform_unit]
+					id=$second_unit.id
+					[filter_wml]
+						usage=fighter
+					[/filter_wml]
+					transform_to=Steel Slasher
+				[/transform_unit]
+				[transform_unit]
+					id=$second_unit.id
+					[filter_wml]
+						usage=archer
+					[/filter_wml]
+					[has_attack]
+						type=fire,cold,arcane,electric
+					[/has_attack]
+					transform_to=Steel Larva
+				[/transform_unit]
+				[transform_unit]
+					id=$second_unit.id
+					[filter_wml]
+						usage=archer
+					[/filter_wml]
+					[has_attack]
+						type=pierce,impact,blade
+					[/has_attack]
+					transform_to=Steel Larva
+				[/transform_unit]
+				[transform_unit]
+					id=$second_unit.id
+					[filter_wml]
+						usage=mixed fighter
+					[/filter_wml]
+					transform_to=Steel Oculus
+				[/transform_unit]
+				[modify_unit]
+					[filter]
+						id=$second_unit.id
+					[/filter]
+					side=$unit.side
+				[/modify_unit]
+			[/then]
+		[/if]
+	[/event]
+	
+	[event]
+		name=defender hits
+		first_time_only=no
+		[filter_second]
+			ability=mechanizing_virus
+		[/filter_second]
+		[filter]
+			[not]
+				race=steelhive
+			[/not]
+			[not]
+				canrecruit=yes
+			[/not]
+			formula="hitpoints>0"
+		[/filter]
+		[filter_second_attack]
+			range=melee
+		[/filter_second_attack]
+		{VARIABLE_OP infection rand (1..100)}
+		[if]
+			[variable]
+				name=infection
+				less_than_equal_to=5
+			[/variable]
+			[then]
+				[transform_unit]
+					id=$unit.id
+					[filter_wml]
+						usage=scout
+					[/filter_wml]
+					transform_to=Steel Wyrm
+				[/transform_unit]
+				[transform_unit]
+					id=$unit.id
+					[filter_wml]
+						usage=fighter
+					[/filter_wml]
+					transform_to=Steel Slasher
+				[/transform_unit]
+				[transform_unit]
+					id=$unit.id
+					[filter_wml]
+						usage=archer
+					[/filter_wml]
+					[has_attack]
+						type=fire,cold,arcane,electric
+					[/has_attack]
+					transform_to=Steel Larva
+				[/transform_unit]
+				[transform_unit]
+					id=$unit.id
+					[filter_wml]
+						usage=archer
+					[/filter_wml]
+					[has_attack]
+						type=pierce,impact,blade
+					[/has_attack]
+					transform_to=Steel Larva
+				[/transform_unit]
+				[transform_unit]
+					id=$unit.id
+					[filter_wml]
+						usage=mixed fighter
+					[/filter_wml]
+					transform_to=Steel Oculus
+				[/transform_unit]
+				[modify_unit]
+					[filter]
+						id=$unit.id
+					[/filter]
+					side=$second_unit.side
+				[/modify_unit]
+			[/then]
+		[/if]
+	[/event]
+#enddef

--- a/macros/wol-resource-tags.cfg
+++ b/macros/wol-resource-tags.cfg
@@ -161,6 +161,7 @@
     {ABILITY_DISENGAGE_EVENTS}
     {~add-ons/War_of_Legends/macros/curse-global-events.cfg}
     {TERRAIN_LINK_GLOBAL_EVENTS}
+	{ABILITY_STEELHIVE_EVENTS}
 [/resource]
 
 # individual resources
@@ -198,6 +199,20 @@
 
     {WEAPON_SPECIAL_DAZE_EVENTS}
     {ABILITY_DISENGAGE_EVENTS}
+[/resource]
+
+[resource]
+    id=WOL_resource_abilities_events_steelhive
+
+    [event]
+        name="preload"
+        first_time_only=no
+        [lua]
+            code= << wesnoth.require "~add-ons/War_of_Legends/lua/theme.lua" >>
+        [/lua]
+    [/event]
+
+    {ABILITY_STEELHIVE_EVENTS}
 [/resource]
 
 [resource]

--- a/units/steelhive/steel_astigmatic.cfg
+++ b/units/steelhive/steel_astigmatic.cfg
@@ -19,6 +19,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=spin
         description=_"spin"

--- a/units/steelhive/steel_cataract.cfg
+++ b/units/steelhive/steel_cataract.cfg
@@ -18,6 +18,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=spin
         description=_"spin"

--- a/units/steelhive/steel_choron.cfg
+++ b/units/steelhive/steel_choron.cfg
@@ -21,6 +21,7 @@
     {STEELHIVE_SOUND:HIT}
     [abilities]
         {ABILITY_EXTRA_HEAL}
+		{ABILITY_MECHANIZING_VIRUS}
     [/abilities]
     [attack]
         name=pincer

--- a/units/steelhive/steel_dreadnought.cfg
+++ b/units/steelhive/steel_dreadnought.cfg
@@ -19,6 +19,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [movement_costs]
         deep_water=1
         shallow_water=1

--- a/units/steelhive/steel_fideliant.cfg
+++ b/units/steelhive/steel_fideliant.cfg
@@ -20,6 +20,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=lance
         description=_"lance"

--- a/units/steelhive/steel_hedron.cfg
+++ b/units/steelhive/steel_hedron.cfg
@@ -20,6 +20,7 @@
     {STEELHIVE_SOUND:HIT}
     [abilities]
         {ABILITY_HEALS}
+		{ABILITY_MECHANIZING_VIRUS}
     [/abilities]
     [attack]
         name=pedipalp

--- a/units/steelhive/steel_impaler.cfg
+++ b/units/steelhive/steel_impaler.cfg
@@ -18,6 +18,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=quill
         description=_"quill"

--- a/units/steelhive/steel_larva.cfg
+++ b/units/steelhive/steel_larva.cfg
@@ -22,6 +22,9 @@
     gender=female
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
 
     [attack]
         name=jolt

--- a/units/steelhive/steel_leviathan.cfg
+++ b/units/steelhive/steel_leviathan.cfg
@@ -23,6 +23,7 @@
         {ABILITY_SKIRMISHER}
         {ABILITY_SUBMERGE}
         {ABILITY_REGENERATES}
+		{ABILITY_MECHANIZING_VIRUS}
     [/abilities]
     [attack]
         name=constrict

--- a/units/steelhive/steel_nymph.cfg
+++ b/units/steelhive/steel_nymph.cfg
@@ -19,6 +19,9 @@
     gender=female
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
 
     [attack]
         name=slash

--- a/units/steelhive/steel_oculus.cfg
+++ b/units/steelhive/steel_oculus.cfg
@@ -18,6 +18,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=spin
         description=_"spin"

--- a/units/steelhive/steel_serpent.cfg
+++ b/units/steelhive/steel_serpent.cfg
@@ -21,6 +21,7 @@
     [abilities]
         {ABILITY_SKIRMISHER}
         {ABILITY_SUBMERGE}
+		{ABILITY_MECHANIZING_VIRUS}
     [/abilities]
     [attack]
         name=ram

--- a/units/steelhive/steel_skewer.cfg
+++ b/units/steelhive/steel_skewer.cfg
@@ -18,6 +18,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=quill
         description=_"quill"

--- a/units/steelhive/steel_slasher.cfg
+++ b/units/steelhive/steel_slasher.cfg
@@ -18,6 +18,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=slash
         description=_"slash"

--- a/units/steelhive/steel_syren.cfg
+++ b/units/steelhive/steel_syren.cfg
@@ -24,6 +24,9 @@
     gender=female
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
 
     [attack]
         name=slash

--- a/units/steelhive/steel_vector.cfg
+++ b/units/steelhive/steel_vector.cfg
@@ -18,6 +18,9 @@
 
     {STEELHIVE_SOUND:DIE}
     {STEELHIVE_SOUND:HIT}
+	[abilities]
+		{ABILITY_MECHANIZING_VIRUS}
+    [/abilities]
     [attack]
         name=blade
         description=_"blade"

--- a/units/steelhive/steel_vorpal.cfg
+++ b/units/steelhive/steel_vorpal.cfg
@@ -21,6 +21,7 @@
     {STEELHIVE_SOUND:HIT}
     [abilities]
         {ABILITY_STEADFAST}
+		{ABILITY_MECHANIZING_VIRUS}
     [/abilities]
     [attack]
         name=blade

--- a/units/steelhive/steel_wyrm.cfg
+++ b/units/steelhive/steel_wyrm.cfg
@@ -20,6 +20,7 @@
     {STEELHIVE_SOUND:HIT}
     [abilities]
         {ABILITY_SUBMERGE}
+		{ABILITY_MECHANIZING_VIRUS}
     [/abilities]
     [attack]
         name=ram


### PR DESCRIPTION
Add the Mechanizing Virus to Steelhive units

### Describe your pull request does
This pull request add the Mechanizing Virus ability:
"Each time this unit hits with a melee weapon, it has a 5% chance to transmit the mechanizing virus, turning the enemy into a member of the Steelhive."
It also adds it too all Steelhive units except the Splicer because of berserk that combos with Mechanizing Virus. The lore reason is that the Splicer is the result of the virus going wild.