### PR TITLE
Check of Steel Dominant health now happens after healing at the begin…

### DIFF
--- a/units/steelhive/steel_dominant.cfg
+++ b/units/steelhive/steel_dominant.cfg
@@ -165,7 +165,7 @@
     [/variation]
 
     [event]
-        name=side turn
+        name=turn refresh
         id=dominant_injuries
         first_time_only=no
         [store_unit]


### PR DESCRIPTION
Changed "turn side" to "turn refresh" so that the check of unit health happens after healing at the beginning of the turn.  