### PR TITLE
AMLA Preview Dialog: Update deprecated gui code and add new resource

### DIFF
--- a/macros/wol-resource-tags.cfg
+++ b/macros/wol-resource-tags.cfg
@@ -1239,6 +1239,30 @@
     [/event]
 [/resource]
 
+[resource]
+    id=WOL_resource_AMLA_preview_only
+
+    [event]
+        name="preload"
+        first_time_only=no
+
+        [lua]
+            code= << wesnoth.require "~add-ons/War_of_Legends/lua/base.lua" >>
+        [/lua]
+        [lua]
+            code= << wesnoth.require "~add-ons/War_of_Legends/lua/gui/amla_list.lua" >>
+        [/lua]
+    [/event]
+
+    # add AMLA menu
+
+    [event]
+        name="prestart"
+
+        {AMLA_MENU}
+    [/event]
+[/resource]
+
 # deep elf faction resource
 [resource]
     id=wol_deep_elves_minotaur_upkeep


### PR DESCRIPTION
1. Update deprecated Lua gui code.
2. Add new resource for showing the advancements preview dialog, without any AMLA overwrite.
3. Changed the title to use script font (Oldania).
4. Make the checkbox message more user friendly.

![Screenshot from 2024-08-09 20-07-50](https://github.com/user-attachments/assets/8118439c-5175-49be-8634-539e0494c48d)

Preview of new resource with script title.