### PR TITLE
Replace djinn with mistral in unit description

### DIFF
--- a/units/elementals/stable/Mistral.cfg
+++ b/units/elementals/stable/Mistral.cfg
@@ -19,7 +19,7 @@
     cost=54
     usage=archer
     die_sound=wail-long.wav
-    description= _ "Djinns are truly mighty windspirits who can decimate armies with their powerful winds, and strike down men with their glistening scimitar."
+    description= _ "Mistrals are truly mighty windspirits who can decimate armies with their powerful winds, and strike down men with their glistening scimitar."
 
     {DEFENSE_ANIM "units/elementals/djinn.png" "units/elementals/djinn.png" wail.wav }
     [attack]


### PR DESCRIPTION
The Mistral unit description still calls them djinns. Feels a bit weird since their called Mistrals in WoL and jinn means something else in Wesnoth now.