### PR TITLE
nerf Water Daemon

### DIFF
--- a/units/elementals/Water_Daemon_1.cfg
+++ b/units/elementals/Water_Daemon_1.cfg
@@ -5,7 +5,7 @@
     race=elemental
     {WATER_ELEMENTAL_TRAITS}
     image="units/elemental-daemons/elemental-water1.png"
-    hitpoints=30
+    hitpoints=24
     movement_type=swimmer
     movement=6
     experience=38
@@ -141,8 +141,8 @@
         icon=attacks/iceball.png
         type=cold
         range=melee
-        damage=8
-        number=2
+        damage=3
+        number=3
         [specials]
             {WEAPON_SPECIAL_COLD_INFLICTION}
         [/specials]

--- a/units/elementals/Water_Daemon_2.cfg
+++ b/units/elementals/Water_Daemon_2.cfg
@@ -5,7 +5,7 @@
     race=elemental
     {WATER_ELEMENTAL_TRAITS}
     image="units/elemental-daemons/water-avatar1.png"
-    hitpoints=44
+    hitpoints=36
     movement_type=swimmer
     movement=6
     experience=125
@@ -123,8 +123,8 @@
         icon=attacks/iceball.png
         type=cold
         range=melee
-        damage=13
-        number=2
+        damage=5
+        number=3
         [specials]
             {WEAPON_SPECIAL_COLD_INFLICTION}
         [/specials]
@@ -135,7 +135,7 @@
         icon=attacks/waterspray.png
         type=pierce
         range=ranged
-        damage=6
+        damage=4
         number=8
         [specials]
             {WEAPON_SPECIAL_SWARM}

--- a/units/elementals/Water_Daemon_3.cfg
+++ b/units/elementals/Water_Daemon_3.cfg
@@ -5,7 +5,7 @@
     race=elemental
     {WATER_ELEMENTAL_TRAITS}
     image="units/elemental-daemons/water-god1.png"
-    hitpoints=61
+    hitpoints=50
     movement_type=swimmer
     movement=6
     experience=150
@@ -155,8 +155,8 @@
         icon=attacks/iceball.png
         type=cold
         range=melee
-        damage=18
-        number=2
+        damage=6
+        number=3
         [specials]
             {WEAPON_SPECIAL_COLD_INFLICTION}
         [/specials]
@@ -180,7 +180,7 @@
         icon=attacks/waterspray.png
         type=pierce
         range=ranged
-        damage=8
+        damage=5
         number=9
         [specials]
             {WEAPON_SPECIAL_SWARM}


### PR DESCRIPTION
Super-nerf the Water Daemon line.
L3 was similar in strength to a L6/7 (72 ranged damage, regen, heal 8, cures, submerge)
L2 also had similar stats to a mainline L3
L1 is only slightly adjusted.


All recieved HP nerfs because they can regen/heal.