### PR TITLE
Adjust arcane resistances of units to be same as 1.16 version of WoL

### DIFF
--- a/units/aberrations.cfg
+++ b/units/aberrations.cfg
@@ -54,7 +54,7 @@
         impact="100"
         fire="90"
         cold="90"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -104,7 +104,7 @@
         impact="90"
         fire="90"
         cold="90"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -154,7 +154,7 @@
         impact="120"
         fire="90"
         cold="90"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 

--- a/units/carapaces.cfg
+++ b/units/carapaces.cfg
@@ -55,7 +55,7 @@
         impact=70
         fire=60
         cold=120
-        arcane=110
+        arcane=120
     [/resistance]
 [/movetype]
 

--- a/units/elves-wood/Avatar.cfg
+++ b/units/elves-wood/Avatar.cfg
@@ -29,7 +29,7 @@ Needless to say, these skills could be used to destroy the elvish civilization. 
 
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
     [resistance]
-        arcane=90
+        arcane=80
         fire=90
     [/resistance]
 

--- a/units/human-aragwaithi.cfg
+++ b/units/human-aragwaithi.cfg
@@ -71,7 +71,7 @@ Albeit being humans, many of their customs and racial features are incredibly di
         impact=100
         fire=100
         cold=100
-        arcane=90
+        arcane=80
     [/resistance]
 [/movetype]
 
@@ -113,7 +113,7 @@ Albeit being humans, many of their customs and racial features are incredibly di
         impact=70
         fire=100
         cold=100
-        arcane=90
+        arcane=80
     [/resistance]
 [/movetype]
 

--- a/units/human-legion/Doctor.cfg
+++ b/units/human-legion/Doctor.cfg
@@ -29,7 +29,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         {ABILITY_CURES}
     [/abilities]
     [resistance]
-        arcane=50
+        arcane=40
     [/resistance]
     [healing_anim]
         start_time=-525

--- a/units/human-legion/Healer.cfg
+++ b/units/human-legion/Healer.cfg
@@ -26,7 +26,7 @@
         {ABILITY_CURES}
     [/abilities]
     [resistance]
-        arcane=70
+        arcane=60
     [/resistance]
     [healing_anim]
         start_time=-525

--- a/units/human-loyalists/Loyalist_Chevalier.cfg
+++ b/units/human-loyalists/Loyalist_Chevalier.cfg
@@ -24,7 +24,7 @@
 
     [resistance]
         blade=80
-        arcane=80
+        arcane=70
         impact=80
     [/resistance]
     [abilities]

--- a/units/human-loyalists/Loyalist_Crusader.cfg
+++ b/units/human-loyalists/Loyalist_Crusader.cfg
@@ -26,7 +26,7 @@
     [resistance]
         blade=80
         impact=80
-        arcane=70
+        arcane=60
     [/resistance]
     [abilities]
         {ABILITY_RADIANCE}

--- a/units/minotaurs.cfg
+++ b/units/minotaurs.cfg
@@ -51,7 +51,7 @@ Minotaurs fight well in forests and mountains but fight poorly in open fields, a
         impact=80
         fire=110
         cold=90
-        arcane=110
+        arcane=130
     [/resistance]
 [/movetype]
 
@@ -93,7 +93,7 @@ Minotaurs fight well in forests and mountains but fight poorly in open fields, a
         impact=100
         fire=110
         cold=90
-        arcane=110
+        arcane=130
     [/resistance]
 [/movetype]
 
@@ -140,7 +140,7 @@ Minotaurs fight well in forests and mountains but fight poorly in open fields, a
         impact=100
         fire=90
         cold=90
-        arcane=120
+        arcane=140
     [/resistance]
 [/movetype]
 

--- a/units/nightmares-elementals.cfg
+++ b/units/nightmares-elementals.cfg
@@ -77,7 +77,7 @@ A literal example of the inefficiency inherent in power increase is the growth o
         impact="70"
         fire="50"
         cold="120"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -128,7 +128,7 @@ A literal example of the inefficiency inherent in power increase is the growth o
         impact="60"
         fire="150"
         cold="90"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -179,7 +179,7 @@ A literal example of the inefficiency inherent in power increase is the growth o
         impact="80"
         fire="90"
         cold="90"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -230,7 +230,7 @@ A literal example of the inefficiency inherent in power increase is the growth o
         impact="130"
         fire="150"
         cold="30"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -282,7 +282,7 @@ A literal example of the inefficiency inherent in power increase is the growth o
         impact="70"
         fire="100"
         cold="100"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 
@@ -334,7 +334,7 @@ A literal example of the inefficiency inherent in power increase is the growth o
         impact="110"
         fire="80"
         cold="80"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 

--- a/units/nightmares.cfg
+++ b/units/nightmares.cfg
@@ -57,7 +57,7 @@
         impact="50"
         fire="100"
         cold="50"
-        arcane="110"
+        arcane="130"
     [/resistance]
 [/movetype]
 

--- a/units/nightmares.cfg
+++ b/units/nightmares.cfg
@@ -57,7 +57,7 @@
         impact="50"
         fire="100"
         cold="50"
-        arcane="130"
+        arcane="110"
     [/resistance]
 [/movetype]
 

--- a/units/steelhive.cfg
+++ b/units/steelhive.cfg
@@ -114,7 +114,7 @@ The origin of the Steelhive is largely unknown, but the first documented appeara
         impact=115
         fire=80
         cold=80
-        arcane=110
+        arcane=120
     [/resistance]
 [/movetype]
 
@@ -317,7 +317,7 @@ The origin of the Steelhive is largely unknown, but the first documented appeara
         impact=75
         fire=120
         cold=100
-        arcane=115
+        arcane=135
     [/resistance]
 [/movetype]
 

--- a/units/undead.cfg
+++ b/units/undead.cfg
@@ -40,7 +40,7 @@
         impact=110
         fire=120
         cold=40
-        arcane=120
+        arcane=150
     [/resistance]
 [/movetype]
 

--- a/units/undead/Necro_Elder_Lich_Lord.cfg
+++ b/units/undead/Necro_Elder_Lich_Lord.cfg
@@ -21,7 +21,7 @@
         {ABILITY_OBSCURE}
     [/abilities]
     [resistance]
-        arcane=120
+        arcane=140
         fire=100
     [/resistance]
     experience=200

--- a/units/undead/Necro_Lich_Lord.cfg
+++ b/units/undead/Necro_Lich_Lord.cfg
@@ -20,7 +20,7 @@
         {ABILITY_OBSCURE}
     [/abilities]
     [resistance]
-        arcane=120
+        arcane=140
         fire=100
     [/resistance]
     experience=250

--- a/units/vampires.cfg
+++ b/units/vampires.cfg
@@ -64,7 +64,7 @@ Since blood is a very important part of vampire society, it is used as their cur
         impact=100
         fire=120
         cold=100
-        arcane=110
+        arcane=120
     [/resistance]
 [/movetype]
 
@@ -106,7 +106,7 @@ Since blood is a very important part of vampire society, it is used as their cur
         impact=60
         fire=120
         cold=100
-        arcane=110
+        arcane=120
     [/resistance]
 [/movetype]
 

--- a/units/windsong.cfg
+++ b/units/windsong.cfg
@@ -65,7 +65,7 @@
         impact=110
         fire=90
         cold=90
-        arcane=90
+        arcane=80
     [/resistance]
 [/movetype]
 
@@ -113,7 +113,7 @@
         impact=90
         fire=90
         cold=110
-        arcane=90
+        arcane=80
     [/resistance]
 [/movetype]
 
@@ -157,7 +157,7 @@
         impact=100
         fire=100
         cold=100
-        arcane=90
+        arcane=80
     [/resistance]
 [/movetype]
 

--- a/units/windsong/Librarian.cfg
+++ b/units/windsong/Librarian.cfg
@@ -14,7 +14,7 @@
     hitpoints=61
     movement_type=windsongsmallfoot
     [resistance]
-        arcane=80
+        arcane=70
         fire=90
         cold=90
     [/resistance]


### PR DESCRIPTION
This PR adjusts the arcane resistances to be in line with the 1.16 version of WoL in case mainline arcane gets changed back.